### PR TITLE
Async loading of maps API

### DIFF
--- a/jquery.gmap.js
+++ b/jquery.gmap.js
@@ -10,6 +10,23 @@
 	// Main plugin function
 	$.fn.gMap = function(options, methods_options)
 	{
+    //Asynchronously load Maps API
+    if (!window.google || !google.maps)
+    {
+      var $this = this, args = arguments, cb = 'callback_' + Math.random().toString().replace('.', '');
+      window[cb] = function()
+      {
+        $.fn.gMap.apply($this, args);
+        window[cb] = null;
+        try
+        {
+          delete window[cb];
+        } catch(e) {}
+      };
+      $.getScript(location.protocol + '//maps.googleapis.com/maps/api/js?v=3&sensor=false&callback=' + cb);
+      return this;
+    }
+
 		// Optional methods
 		switch(options)
 		{


### PR DESCRIPTION
Hi marioestrada,

I added 16 lines to your jQuery.gmap.js so that the plugin no longer requires the API script tag to be hardcoded onto the page:

<script type="text/javascript" src="http://maps.google.com/maps/api/js?sensor=true"></script>


The code I added checks for the presence of the global variable google.maps and if not present loads this script asynchronously. This will decrease delay at page load among other advantages.

I hope you find this helpful.

Cheers,
Simon
