### PR TITLE
Update jquery.gmap.js

### DIFF
--- a/jquery.gmap.js
+++ b/jquery.gmap.js
@@ -260,8 +260,8 @@
     html_prepend: '<div class="gmap_marker">',
     html_append: '</div>',
     icon: {
-      image: "http://www.google.com/mapfiles/marker.png",
-      shadow: "http://www.google.com/mapfiles/shadow50.png",
+      image: "https://www.google.com/mapfiles/marker.png",
+      shadow: "https://www.google.com/mapfiles/shadow50.png",
       iconsize: [20, 34],
       shadowsize: [37, 34],
       iconanchor: [9, 34],


### PR DESCRIPTION
The marker and shadow PNGs are causing SSL errors when used on an HTTPS page
